### PR TITLE
feat: respect GitHub Pages base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(async ({ command, mode }) => {
   
   // For custom domain (digi-twin.tervahagn.com), use root path
   // For github.io subdomain, use /digi-twin/
-  const basePath = isDev ? "/" : "/";
+  const basePath = isDev ? "/" : (isGitHubPages ? "/digi-twin/" : "/");
 
   return {
     plugins: [


### PR DESCRIPTION
## Summary
- switch Vite base path based on `GITHUB_PAGES` flag

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:gh-pages`


------
https://chatgpt.com/codex/tasks/task_e_689507be7638832fadb84521b79913cd